### PR TITLE
Guzzle versions 6+ and 7+ are now supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	],
 	"require": {
 		"php": "^5.6|^7.0",
-		"guzzlehttp/guzzle": "^6.0"
+		"guzzlehttp/guzzle": "^6.0|^7.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "^0.8",


### PR DESCRIPTION
Fixes #9